### PR TITLE
Fix getAcquiredLocks()

### DIFF
--- a/spec/integration/lockIntegrationSpec.js
+++ b/spec/integration/lockIntegrationSpec.js
@@ -168,13 +168,13 @@ describe('lock', () => {
       const oldLockCount = redislock.getAcquiredLocks().length
       return lock.acquire(key).then(() => {
         expect(redislock.getAcquiredLocks()).to.have.length(oldLockCount + 1);
-        let recount = 0
+        let recount = 0;
         redislock.getAcquiredLocks().forEach((l) => {
-          recount ++
-          expect(l).to.be.a(Lock)
+          recount ++;
+          expect(l).to.be.a(Lock);
         })
         expect(recount).to.eql(oldLockCount + 1);
-        return lock.release()
+        return lock.release();
       }).then(() => {
         expect(redislock.getAcquiredLocks()).to.have.length(oldLockCount);
       });

--- a/spec/integration/lockIntegrationSpec.js
+++ b/spec/integration/lockIntegrationSpec.js
@@ -149,7 +149,7 @@ describe('lock', () => {
     });
 
     it('throws an error if the key no longer belongs to the lock', () => {
-      lock.acquire(key).then(() => {
+      return lock.acquire(key).then(() => {
         return client.set(key, 'mismatch');
       }).then(() => {
         return lock.extend(10000);

--- a/spec/integration/lockIntegrationSpec.js
+++ b/spec/integration/lockIntegrationSpec.js
@@ -165,7 +165,7 @@ describe('lock', () => {
 
   describe('getAcquiredLocks', () => {
     it('returns an array of locks', () => {
-      const oldLockCount = redislock.getAcquiredLocks().length
+      const oldLockCount = redislock.getAcquiredLocks().length;
       return lock.acquire(key).then(() => {
         expect(redislock.getAcquiredLocks()).to.have.length(oldLockCount + 1);
         let recount = 0;
@@ -179,5 +179,5 @@ describe('lock', () => {
         expect(redislock.getAcquiredLocks()).to.have.length(oldLockCount);
       });
     });
-  })
+  });
 });

--- a/spec/integration/lockIntegrationSpec.js
+++ b/spec/integration/lockIntegrationSpec.js
@@ -8,6 +8,7 @@ const expect = require('expect.js');
 const Redis = require('ioredis');
 const client = new Redis();
 const redislock = require('../../lib/redislock');
+const Lock = require('../../lib/lock');
 
 const LockAcquisitionError = redislock.LockAcquisitionError;
 const LockReleaseError = redislock.LockReleaseError;
@@ -161,4 +162,22 @@ describe('lock', () => {
       });
     });
   });
+
+  describe('getAcquiredLocks', () => {
+    it('returns an array of locks', () => {
+      const oldLockCount = redislock.getAcquiredLocks().length
+      return lock.acquire(key).then(() => {
+        expect(redislock.getAcquiredLocks()).to.have.length(oldLockCount + 1);
+        let recount = 0
+        redislock.getAcquiredLocks().forEach((l) => {
+          recount ++
+          expect(l).to.be.a(Lock)
+        })
+        expect(recount).to.eql(oldLockCount + 1);
+        return lock.release()
+      }).then(() => {
+        expect(redislock.getAcquiredLocks()).to.have.length(oldLockCount);
+      });
+    });
+  })
 });

--- a/src/redislock.js
+++ b/src/redislock.js
@@ -40,13 +40,7 @@ exports.setDefaults = function setDefaults(options = {}) {
  * @return {Lock[]} An array of Lock objects
  */
 exports.getAcquiredLocks = function getAcquiredLocks() {
-  const locks = new Array(Lock._acquiredLocks.size);
-
-  Lock._acquiredLocks.forEach((lock, idx) => {
-    locks[idx] = lock;
-  });
-
-  return locks;
+  return Array.from(Lock._acquiredLocks);
 };
 
 /**


### PR DESCRIPTION
Hi,

I noticed that the array returned by getAcquiredLocks() not always contains all locks.
The reason seems to be that the key that is returned by Set.forEach() during construction of this array is not really numeric.

This PR creates a test for this (and also fixes a tiny glitch in an existing test), and fixes getAcquiredLocks to use Array.from(Set), which is smaller, faster and more correct imho.

Cheers,
  bkw